### PR TITLE
fixed an issue with invalid format string (preventing game start on my system)

### DIFF
--- a/zscript/sharddx/handler/titlemap.zsc
+++ b/zscript/sharddx/handler/titlemap.zsc
@@ -126,7 +126,7 @@ class SHDX_TitlemapEvent : EventHandler
 		String mp = CVar.GetCvar('r_multithreaded', players[consoleplayer]).GetBool() ? StringTable.Localize("$SHDX_TITLEMAP_MULTI") : "";
 		if (!hal)
 		{
-			lawg = String.Format("%s %s %s %s %s\n%s %s", StringTable.Localize("$SHDX_TITLEMAP_FINAL1"), StringTable.Localize("$SHDX_TITLEMAP_FINAL2"),
+			lawg = String.Format("%s %s %s %s %s\n%s", StringTable.Localize("$SHDX_TITLEMAP_FINAL1"), StringTable.Localize("$SHDX_TITLEMAP_FINAL2"),
 												StringTable.Localize("$SHDX_BUILDNUM"), StringTable.Localize("$SHDX_TITLEMAP_VERSION"), StringTable.Localize("$SHDX_TITLEMAP_FINAL3"), mp);
 		}
 		else


### PR DESCRIPTION
When I downloaded the pk3 from the site, I had a problem preventing the game to start. This was due to having 7 %s where there where only 6 input string. This fixed the issue.

A bit unrelated: you should link to this github in the page (I found this while searching on google for your discord), and you mention in the error message I could send a discord PM, but there doesn't seem to have a discord id.